### PR TITLE
Run mypy and fix return type

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/src/risk/var.py
+++ b/src/risk/var.py
@@ -97,7 +97,8 @@ def monte_carlo_var(
     std = returns.std()
     sims = np.random.normal(mean, std, simulations)
     var = np.percentile(sims, (1 - confidence_level) * 100)
-    return abs(var)
+    # np.percentile returns a numpy scalar; cast to float for clarity
+    return float(abs(var))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `mypy.ini` so missing-import problems don't fail the run
- fix Monte Carlo VaR to return a Python `float`

## Testing
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c74eda56c8324bb14c4176dc1cdd5