### PR TITLE
Add CI workflow and update README testing instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install -e .
+    - name: Run tests
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ Rather than fitting VaR once on the full sample, we:
 └── pytest.ini
 ```
 
+## Running Tests
+
+Install dependencies before invoking `pytest` to avoid missing packages:
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+pytest
+```
+
 
 ## 5. References
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c75a7a45c8324a720a38865a305ea