### PR TITLE
Replace setup.py with pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ This repository implements a production-grade pipeline for computing and backtes
 
 Parameters (confidence level, horizon, EWMA λ) live in **`config.py`** for rapid scenario analysis.
 
+## Installation
+
+Install the project in editable mode so tests and scripts resolve the `risk` package:
+
+```bash
+pip install -e .
+```
+
+After installation run the example CLI:
+
+```bash
+risk-example
+```
+
 ---
 
 ## 2. Theoretical Background
@@ -109,7 +123,7 @@ Rather than fitting VaR once on the full sample, we:
 │   ├── processed
 │   └── raw
 ├── requirements.txt
-├── setup.py
+├── pyproject.toml
 └── pytest.ini
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "risk"
+version = "0.1.0"
+description = "Quantitative VaR backtesting framework"
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.8"
+
+# runtime dependencies
+dependencies = [
+    "numpy>=1.21",
+    "pandas>=1.3",
+    "scipy>=1.7",
+    "matplotlib>=3.5",
+    "yfinance>=0.2"
+]
+
+[project.scripts]
+risk-example = "risk.var:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup, find_packages
-
-setup(
-    name='risk',
-    version='0.1.0',
-    package_dir={'': 'src'},
-    packages=find_packages(where='src'),
-)

--- a/src/risk/var.py
+++ b/src/risk/var.py
@@ -101,12 +101,16 @@ def monte_carlo_var(
     return float(abs(var))
 
 
-if __name__ == "__main__":
-    # Simple example usage
-    example = os.path.join(PROCESSED_DATA_DIR, '2025-03-30_sp500.csv')
+def main() -> None:
+    """Run a simple VaR demo on example data."""
+    example = os.path.join(PROCESSED_DATA_DIR, "2025-03-30_sp500.csv")
     df = pd.read_csv(example, index_col=0)
     prices = df.iloc[:, 0]
     rets = calculate_daily_returns(prices)
     print("Historical VaR:", historical_var(rets))
     print("Parametric VaR:", parametric_var(rets))
     print("Monte Carlo VaR:", monte_carlo_var(rets))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- migrate packaging to `pyproject.toml`
- document editable installation and CLI in README
- remove old `setup.py`
- add `main()` helper for CLI entry point

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c7654e328832483993ba877e3964b