### PR TITLE
Add plotting tests

### DIFF
--- a/src/risk/plotting.py
+++ b/src/risk/plotting.py
@@ -15,7 +15,7 @@ def plot_var_breaches(
     breach_col: str = 'breach',
     return_col: str = 'ret_10d',
     var_col: str = 'var_10d'
-) -> None:
+) -> plt.Figure:
     """
     Plot returns, VaR threshold, and breach points on a single axes.
     """
@@ -38,6 +38,8 @@ def plot_var_breaches(
     ax.set_ylabel('Returns')
     ax.legend()
 
+    return ax.figure
+
 
 def plot_multiple_var_breaches(
     data_list: List[pd.DataFrame],
@@ -46,7 +48,7 @@ def plot_multiple_var_breaches(
     return_col: str = 'ret_10d',
     var_col: str = 'var_10d',
     figsize: tuple = (20, 5)
-) -> None:
+) -> plt.Figure:
     """
     Stack multiple VaR breach plots vertically for comparison.
     """
@@ -61,3 +63,4 @@ def plot_multiple_var_breaches(
 
     plt.tight_layout()
     plt.show()
+    return fig

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,39 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from risk.plotting import plot_var_breaches, plot_multiple_var_breaches
+from risk.utils import detect_var_breaches
+
+
+def make_dummy_df():
+    df = pd.DataFrame(
+        {
+            'ret_10d': [0.02, -0.05, 0.01],
+            'var_10d': [-0.03, -0.03, -0.03],
+        },
+        index=pd.date_range('2020-01-01', periods=3),
+    )
+    return detect_var_breaches(df, return_col='ret_10d', var_col='var_10d', breach_col='breach')
+
+
+def test_plot_var_breaches_returns_figure():
+    df = make_dummy_df()
+    fig, ax = plt.subplots()
+    result = plot_var_breaches(df, ax, title='Test')
+    assert result is fig
+    assert hasattr(result, 'savefig')
+    plt.close(fig)
+
+
+def test_plot_multiple_var_breaches_returns_figure():
+    df1 = make_dummy_df()
+    df2 = make_dummy_df()
+    fig = plot_multiple_var_breaches([df1, df2], titles=['A', 'B'])
+    assert hasattr(fig, 'savefig')
+    plt.close(fig)
+
+    fig_single = plot_multiple_var_breaches([df1], titles=['Single'])
+    assert hasattr(fig_single, 'savefig')
+    plt.close(fig_single)


### PR DESCRIPTION
## Summary
- return `matplotlib` figures from plotting helpers
- ensure plotting works under `Agg` backend
- test plotting outputs and verify returned figure objects

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c75a619148324a19080df4722bb84