### PR TITLE
Use latest processed data in CLI

### DIFF
--- a/src/risk/var.py
+++ b/src/risk/var.py
@@ -6,7 +6,7 @@ import pandas as pd
 from scipy.stats import norm
 
 from config import PROCESSED_DATA_DIR, CONFIDENCE_LEVEL, MONTE_CARLO_SIMULATIONS
-from risk.utils import calculate_daily_returns
+from risk.utils import calculate_daily_returns, load_latest_price_data
 
 
 def historical_var(
@@ -102,11 +102,11 @@ def monte_carlo_var(
 
 
 def main() -> None:
-    """Run a simple VaR demo on example data."""
-    example = os.path.join(PROCESSED_DATA_DIR, "2025-03-30_sp500.csv")
-    df = pd.read_csv(example, index_col=0)
+    """Run a simple VaR demo on the latest processed S&P 500 data."""
+    df = load_latest_price_data(PROCESSED_DATA_DIR, "sp500")
     prices = df.iloc[:, 0]
     rets = calculate_daily_returns(prices)
+    print("Loaded latest S&P 500 prices (rows={})".format(len(df)))
     print("Historical VaR:", historical_var(rets))
     print("Parametric VaR:", parametric_var(rets))
     print("Monte Carlo VaR:", monte_carlo_var(rets))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from importlib import reload
+
+import risk.var as var
+import config
+
+
+def test_risk_example_runs(tmp_path, capsys, monkeypatch):
+    # create simple sp500 CSV
+    df = pd.DataFrame({
+        'Date': pd.date_range('2024-01-01', periods=3),
+        'close': [1.0, 1.1, 1.2],
+    })
+    path = tmp_path / '2024-01-01_sp500.csv'
+    df.to_csv(path, index=False)
+
+    monkeypatch.setattr(config, 'PROCESSED_DATA_DIR', str(tmp_path))
+    monkeypatch.setattr(var, 'PROCESSED_DATA_DIR', str(tmp_path))
+
+    reload(var)  # ensure function picks up new constant
+    var.main()
+    out = capsys.readouterr().out
+    assert 'Historical VaR:' in out
+    assert 'Parametric VaR:' in out
+    assert 'Monte Carlo VaR:' in out
+


### PR DESCRIPTION
## Summary
- load most recent S&P 500 CSV with `load_latest_price_data`
- print row count when running `risk-example`
- add regression test ensuring the CLI works with a temporary processed directory

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0e2be4948324b9f71955daf8c054