### PR TITLE
Streamline comments

### DIFF
--- a/src/risk/plotting.py
+++ b/src/risk/plotting.py
@@ -21,18 +21,18 @@ def plot_var_breaches(
     """
     Plot returns, VaR threshold, and breach points on a single axes.
     """
-    # Force index into real Python datetimes
+    # Convert index to datetime
     x = pd.to_datetime(data.index)
 
-    # Plot the 10-day returns
+    # plot returns
     ax.plot(x, data[return_col], label="10-day returns")
 
-    # Mark breaches
+    # mark breaches
     breaches = data[data[breach_col]]
     bx = pd.to_datetime(breaches.index)
     ax.scatter(bx, breaches[return_col], marker="x", label="VaR Breaches")
 
-    # Plot the 10-day VaR
+    # plot VaR
     ax.plot(x, data[var_col], label="10-day VaR")
 
     ax.set_title(title)

--- a/src/risk/var.py
+++ b/src/risk/var.py
@@ -12,26 +12,7 @@ from risk.utils import calculate_daily_returns, load_latest_price_data
 def historical_var(
     returns: pd.Series, confidence_level: float = CONFIDENCE_LEVEL
 ) -> float:
-    """
-    Compute historical VaR at a specified confidence level.
-
-    Parameters
-    ----------
-    returns
-        Series of daily returns.
-    confidence_level
-        VaR confidence level (e.g. 0.95 for 95%).
-
-    Returns
-    -------
-    float
-        Absolute historical VaR (positive number).
-
-    Raises
-    ------
-    ValueError
-        If the returns series is empty.
-    """
+    """Historical VaR at ``confidence_level``."""
     if returns.empty:
         raise ValueError("Returns series is empty.")
     var_pct = (1 - confidence_level) * 100
@@ -42,26 +23,12 @@ def historical_var(
 def parametric_var(
     returns: pd.Series, confidence_level: float = CONFIDENCE_LEVEL
 ) -> float:
-    """
-    Compute parametric (Gaussian) VaR assuming normal returns.
-
-    Parameters
-    ----------
-    returns
-        Series of daily returns.
-    confidence_level
-        VaR confidence level.
-
-    Returns
-    -------
-    float
-        Absolute parametric VaR.
-    """
+    """Parametric VaR under a normal assumption."""
     if returns.empty:
         raise ValueError("Returns series is empty.")
     mean = returns.mean()
     std = returns.std()
-    # deterministic z-score for the one-tailed lower quantile
+    # one-tailed z-score
     z = norm.ppf(1 - confidence_level)
     var = -(mean + z * std)
     return abs(var)
@@ -72,30 +39,14 @@ def monte_carlo_var(
     confidence_level: float = CONFIDENCE_LEVEL,
     simulations: int = MONTE_CARLO_SIMULATIONS,
 ) -> float:
-    """
-    Compute VaR via Monte Carlo simulation under normality assumption.
-
-    Parameters
-    ----------
-    returns
-        Series of daily returns.
-    confidence_level
-        VaR confidence level.
-    simulations
-        Number of simulated return paths.
-
-    Returns
-    -------
-    float
-        Absolute Monte Carlo VaR.
-    """
+    """Monte Carlo VaR assuming normal returns."""
     if returns.empty:
         raise ValueError("Returns series is empty.")
     mean = returns.mean()
     std = returns.std()
     sims = np.random.normal(mean, std, simulations)
     var = np.percentile(sims, (1 - confidence_level) * 100)
-    # np.percentile returns a numpy scalar; cast to float for clarity
+    # cast numpy scalar to float
     return float(abs(var))
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ from risk.backtests import kupiec_pof_test
 
 
 def test_full_pipeline(tmp_path, capsys, monkeypatch):
-    # mock yfinance.download to return deterministic data
+    # mock yfinance.download
     df = pd.DataFrame(
         {"Close": [100, 101, 102, 103, 104]},
         index=pd.date_range("2024-01-01", periods=5),
@@ -27,7 +27,7 @@ def test_full_pipeline(tmp_path, capsys, monkeypatch):
     monkeypatch.setattr(config, "PROCESSED_DATA_DIR", str(tmp_path))
     monkeypatch.setattr(var, "PROCESSED_DATA_DIR", str(tmp_path))
 
-    # fetch data and write CSV
+    # fetch sample data
     rdata.fetch_and_save_data(
         tickers={"^GSPC": "sp500"},
         start_date="2024-01-01",
@@ -35,14 +35,14 @@ def test_full_pipeline(tmp_path, capsys, monkeypatch):
         output_dir=str(tmp_path),
     )
 
-    reload(var)  # ensure main uses patched constant
+    reload(var)  # pick up patched constant
     var.main()
     out = capsys.readouterr().out
     assert "Historical VaR:" in out
     assert "Parametric VaR:" in out
     assert "Monte Carlo VaR:" in out
 
-    # integration: load saved CSV and run backtest pieces
+    # load CSV and run backtests
     df_loaded = load_latest_price_data(str(tmp_path), "sp500")
     prices = df_loaded.iloc[:, 0]
     rets = calculate_daily_returns(prices)


### PR DESCRIPTION
## Summary
- shorten long function docstrings and comments
- clean up integration tests comments
- minor stylistic edits in utils tests

## Testing
- `black --check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bc2c65c48324bc18bfa92405cd65